### PR TITLE
Fix incorrect function check

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ const copyProps = (fromStream, toStream) => {
 			continue;
 		}
 
-		toStream[prop] = typeof prop === 'function' ? fromStream[prop].bind(fromStream) : fromStream[prop];
+		toStream[prop] = typeof fromStream[prop] === 'function' ? fromStream[prop].bind(fromStream) : fromStream[prop];
 	}
 };
 


### PR DESCRIPTION
I think this is what you intended.

You were checking if the property name was a function rather than the actual value. This can never evaluate to true and so currently any response passed through `decompress-response` will not have its function methods bound to the original response instance.