### PR TITLE
Add support for `br` encoding

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,19 +2,20 @@
 const PassThrough = require('stream').PassThrough;
 const zlib = require('zlib');
 const mimicResponse = require('mimic-response');
+const iltorbDecompress = require('iltorb').decompressStream;
 
 module.exports = response => {
 	// TODO: Use Array#includes when targeting Node.js 6
-	if (['gzip', 'deflate'].indexOf(response.headers['content-encoding']) === -1) {
+	if (['gzip', 'deflate', 'br'].indexOf(response.headers['content-encoding']) === -1) {
 		return response;
 	}
 
-	const unzip = zlib.createUnzip();
+	const decompress = response.headers['content-encoding'] === 'br' ? iltorbDecompress() : zlib.createUnzip();
 	const stream = new PassThrough();
 
 	mimicResponse(response, stream);
 
-	unzip.on('error', err => {
+	decompress.on('error', err => {
 		if (err.code === 'Z_BUF_ERROR') {
 			stream.end();
 			return;
@@ -23,7 +24,7 @@ module.exports = response => {
 		stream.emit('error', err);
 	});
 
-	response.pipe(unzip).pipe(stream);
+	response.pipe(decompress).pipe(stream);
 
 	return stream;
 };

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "compressed"
   ],
   "dependencies": {
+    "iltorb": "^1.3.1",
     "mimic-response": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Went with `iltorb` since it supported streaming, before I saw your comment in https://github.com/sindresorhus/decompress-response/issues/12#issuecomment-308200795. If we want to use the `brotli` it'll need some more work. And we'd be forced to buffer the response first I think.

Fixes #12.