### PR TITLE
Throw more descriptive error when handling truncated responses

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,10 +21,8 @@ const decompressResponse = response => {
 	mimicResponse(response, stream);
 
 	decompress.on('error', error => {
-		// Ignore empty response
 		if (error.code === 'Z_BUF_ERROR') {
 			stream.end();
-			return;
 		}
 
 		stream.emit('error', error);


### PR DESCRIPTION
Fixes #19

<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#19: Handle truncated compressed response (Z_BUF_ERROR)](https://issuehunt.io/repos/39304827/issues/19)
---

IssueHunt has been backed by the following sponsors. [Become a sponsor](https://issuehunt.io/membership/members)
</details>
<!-- /Issuehunt content-->