### PR TITLE
Case-insensitively check the `content-encoding` header

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,9 +6,12 @@ const mimicResponse = require('mimic-response');
 const decompressResponse = response => {
 	const contentEncoding = response.headers['content-encoding'];
 
-	if (!['gzip', 'deflate', 'br'].includes(contentEncoding)) {
-		return response;
-	}
+  if (
+    !contentEncoding ||
+    !['gzip', 'deflate', 'br'].includes(contentEncoding.toLowerCase())
+  ) {
+    return response;
+  }
 
 	const isBrotli = contentEncoding === 'br';
 	if (isBrotli && typeof zlib.createBrotliDecompress !== 'function') {

--- a/index.js
+++ b/index.js
@@ -6,12 +6,12 @@ const mimicResponse = require('mimic-response');
 const decompressResponse = response => {
 	const contentEncoding = response.headers['content-encoding'];
 
-  if (
-    !contentEncoding ||
-    !['gzip', 'deflate', 'br'].includes(contentEncoding.toLowerCase())
-  ) {
-    return response;
-  }
+        if (
+                !contentEncoding ||
+                !['gzip', 'deflate', 'br'].includes(contentEncoding.toLowerCase())
+        ) {
+                return response;
+        }
 
 	const isBrotli = contentEncoding === 'br';
 	if (isBrotli && typeof zlib.createBrotliDecompress !== 'function') {

--- a/index.js
+++ b/index.js
@@ -6,9 +6,9 @@ const mimicResponse = require('mimic-response');
 const decompressResponse = response => {
 	const contentEncoding = (response.headers['content-encoding'] || '').toLowerCase();
 
-        if (!['gzip', 'deflate', 'br'].includes(contentEncoding)) {
-                return response;
-        }
+	if (!['gzip', 'deflate', 'br'].includes(contentEncoding)) {
+		return response;
+	}
 
 	const isBrotli = contentEncoding === 'br';
 	if (isBrotli && typeof zlib.createBrotliDecompress !== 'function') {

--- a/index.js
+++ b/index.js
@@ -4,12 +4,9 @@ const zlib = require('zlib');
 const mimicResponse = require('mimic-response');
 
 const decompressResponse = response => {
-	const contentEncoding = response.headers['content-encoding'];
+	const contentEncoding = (response.headers['content-encoding'] || '').toLowerCase();
 
-        if (
-                !contentEncoding ||
-                !['gzip', 'deflate', 'br'].includes(contentEncoding.toLowerCase())
-        ) {
+        if (!['gzip', 'deflate', 'br'].includes(contentEncoding)) {
                 return response;
         }
 


### PR DESCRIPTION
Some server are uppercasing the `content-encoding` header.

Example to reproduce:
https://typespublisher.blob.core.windows.net/typespublisher/data/search-index-min.json