### PR TITLE
Support for deflate raw (Closes #34)

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -29,6 +29,13 @@ test.before('setup', async () => {
 		response.end(await zlibP.deflate(fixture));
 	});
 
+	server.on('/deflateRaw', async (request, response) => {
+		response.statusCode = 200;
+		response.setHeader('content-encoding-type', 'text/plain');
+		response.setHeader('content-encoding', 'deflate');
+		response.end(await zlibP.deflateRaw(fixture));
+	});
+
 	server.on('/brotli', async (request, response) => {
 		response.statusCode = 200;
 		response.setHeader('content-type', 'text/plain');
@@ -82,6 +89,17 @@ test('decompress gzipped content', async t => {
 
 test('decompress deflated content', async t => {
 	const response = decompressResponse(await httpGetP(`${server.url}/deflate`));
+
+	t.is(typeof response.httpVersion, 'string');
+	t.truthy(response.headers);
+
+	response.setEncoding('utf8');
+
+	t.is(await getStream(response), fixture);
+});
+
+test('decompress raw-deflated content', async t => {
+	const response = decompressResponse(await httpGetP(`${server.url}/deflateRaw`));
 
 	t.is(typeof response.httpVersion, 'string');
 	t.truthy(response.headers);


### PR DESCRIPTION
I've encountered several servers which use the actual `deflate` algorithm when declaring `deflate` as the `Content-Encoding`.
The [RFC](https://datatracker.ietf.org/doc/html/rfc1951) of course states a gzip-compatible compression format.
However, as some people have said before, [the internet is messy](https://github.com/sindresorhus/decompress-response/issues/34#issuecomment-975748134). And I seem to [not be the only one](https://stackoverflow.com/questions/37519828/how-can-we-distinguish-deflate-stream-from-deflateraw-stream) encountering this.

This is a workaround with a simple detection that will pick the right decompression algorithm for the situation.

Fixes #34